### PR TITLE
Supports side-peek layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@linaria/core": "3.0.0-beta.22",
     "@linaria/react": "3.0.0-beta.22",
     "@notionhq/client": "2.1.1",
+    "@xobotyi/scrollbar-width": "1.9.5",
     "react": "18.2.0",
     "react-dom": "18.2.0"
   },

--- a/src/pages/content_script/ContentScriptApp.tsx
+++ b/src/pages/content_script/ContentScriptApp.tsx
@@ -4,10 +4,11 @@ import { NotionContainer } from "~/presentations/templates/NotionContainer";
 import { useLikeButton } from "./useLikeButton";
 
 export const ContentScriptApp = () => {
-  const { isVisible, layout: pageMode, ...likeButtonProps } = useLikeButton();
+  const { isVisible, layout, hasScrollBar, ...likeButtonProps } =
+    useLikeButton();
 
   return isVisible ? (
-    <NotionContainer layout={pageMode}>
+    <NotionContainer layout={layout} hasScrollBar={hasScrollBar}>
       <LikeButton {...likeButtonProps} />
     </NotionContainer>
   ) : null;

--- a/src/pages/content_script/ContentScriptApp.tsx
+++ b/src/pages/content_script/ContentScriptApp.tsx
@@ -4,10 +4,10 @@ import { NotionContainer } from "~/presentations/templates/NotionContainer";
 import { useLikeButton } from "./useLikeButton";
 
 export const ContentScriptApp = () => {
-  const { isVisible, pageMode, ...likeButtonProps } = useLikeButton();
+  const { isVisible, layout: pageMode, ...likeButtonProps } = useLikeButton();
 
   return isVisible ? (
-    <NotionContainer pageMode={pageMode}>
+    <NotionContainer layout={pageMode}>
       <LikeButton {...likeButtonProps} />
     </NotionContainer>
   ) : null;

--- a/src/pages/content_script/useLikeButton.ts
+++ b/src/pages/content_script/useLikeButton.ts
@@ -1,3 +1,4 @@
+import { scrollbarWidth } from "@xobotyi/scrollbar-width";
 import type { ComponentProps } from "react";
 import { useCallback, useEffect, useState } from "react";
 
@@ -16,6 +17,7 @@ type LikeInfo = {
 type HookResult = {
   readonly isVisible: boolean;
   readonly layout: Layout;
+  readonly hasScrollBar: boolean;
 } & ComponentProps<typeof LikeButton>;
 
 export const useLikeButton = (): HookResult => {
@@ -29,6 +31,7 @@ export const useLikeButton = (): HookResult => {
   const [temporaryLikeInfo, setTemporaryLikeInfo] = useState<LikeInfo | null>(
     null
   );
+  const [hasScrollBar] = useState(() => (scrollbarWidth() ?? 0) > 0);
 
   const handleCreateLike = useCallback(() => {
     const { userId, url } = getNotionInfo();
@@ -128,6 +131,7 @@ export const useLikeButton = (): HookResult => {
     ...currentLikeInfo,
     isVisible,
     isSubmitting: !!temporaryLikeInfo,
+    hasScrollBar,
     onCreateLike: handleCreateLike,
     onDeleteLike: handleDeleteLike,
   };

--- a/src/pages/content_script/useLikeButton.ts
+++ b/src/pages/content_script/useLikeButton.ts
@@ -2,22 +2,20 @@ import type { ComponentProps } from "react";
 import { useCallback, useEffect, useState } from "react";
 
 import type { LikeButton } from "~/presentations/organisms/LikeButton";
-import type { RuntimeMessageRequest, TabMessageRequest } from "~/types";
+import type { Layout, RuntimeMessageRequest, TabMessageRequest } from "~/types";
 
 import { getNotionInfo } from "./getNotionInfo";
-
-type PageMode = "page" | "popup";
 
 type LikeInfo = {
   readonly isLiked: boolean;
   readonly likeCount: number;
-  readonly pageMode: PageMode;
+  readonly layout: Layout;
   readonly withAnimation: boolean;
 };
 
 type HookResult = {
   readonly isVisible: boolean;
-  readonly pageMode: PageMode;
+  readonly layout: Layout;
 } & ComponentProps<typeof LikeButton>;
 
 export const useLikeButton = (): HookResult => {
@@ -25,7 +23,7 @@ export const useLikeButton = (): HookResult => {
   const [likeInfo, setLikeInfo] = useState<LikeInfo>({
     isLiked: false,
     likeCount: 0,
-    pageMode: "page",
+    layout: "full-page",
     withAnimation: false,
   });
   const [temporaryLikeInfo, setTemporaryLikeInfo] = useState<LikeInfo | null>(
@@ -39,7 +37,7 @@ export const useLikeButton = (): HookResult => {
     setTemporaryLikeInfo({
       isLiked: true,
       likeCount: likeInfo.likeCount + 1,
-      pageMode: likeInfo.pageMode,
+      layout: likeInfo.layout,
       withAnimation: true,
     });
 
@@ -57,7 +55,7 @@ export const useLikeButton = (): HookResult => {
     setTemporaryLikeInfo({
       isLiked: false,
       likeCount: likeInfo.likeCount - 1,
-      pageMode: likeInfo.pageMode,
+      layout: likeInfo.layout,
       withAnimation: false,
     });
 
@@ -79,7 +77,7 @@ export const useLikeButton = (): HookResult => {
           setLikeInfo({
             isLiked: request.isLiked,
             likeCount: request.likeCount,
-            pageMode: request.pageMode,
+            layout: request.layout,
             withAnimation: false,
           });
           setTemporaryLikeInfo(null);
@@ -90,7 +88,7 @@ export const useLikeButton = (): HookResult => {
           setLikeInfo({
             isLiked: request.isLiked,
             likeCount: request.likeCount,
-            pageMode: request.pageMode,
+            layout: request.layout,
             withAnimation: false,
           });
           setTemporaryLikeInfo(null);

--- a/src/presentations/templates/NotionContainer/NotionContainer.tsx
+++ b/src/presentations/templates/NotionContainer/NotionContainer.tsx
@@ -1,3 +1,4 @@
+import { css, cx } from "@linaria/core";
 import { styled } from "@linaria/react";
 import type { ReactNode } from "react";
 
@@ -5,6 +6,7 @@ import type { Layout } from "~/types";
 
 type Props = {
   readonly layout: Layout;
+  readonly hasScrollBar: boolean;
   readonly children: ReactNode;
 };
 
@@ -14,6 +16,11 @@ const StylePageContainer = styled.div`
   position: fixed;
   right: 64px;
   bottom: 16px;
+`;
+
+const hasScollBarStyle = css`
+  right: 74px;
+  bottom: 26px;
 `;
 
 const StyleCenterPeekContainer = styled.div`
@@ -34,11 +41,13 @@ const StyleCenterPeekInner = styled.div`
   bottom: 16px;
 `;
 
-export const NotionContainer = ({ layout, children }: Props) =>
+export const NotionContainer = ({ layout, hasScrollBar, children }: Props) =>
   layout === "center-peek" ? (
     <StyleCenterPeekContainer>
       <StyleCenterPeekInner>{children}</StyleCenterPeekInner>
     </StyleCenterPeekContainer>
   ) : (
-    <StylePageContainer>{children}</StylePageContainer>
+    <StylePageContainer className={cx(hasScrollBar && hasScollBarStyle)}>
+      {children}
+    </StylePageContainer>
   );

--- a/src/presentations/templates/NotionContainer/NotionContainer.tsx
+++ b/src/presentations/templates/NotionContainer/NotionContainer.tsx
@@ -1,8 +1,10 @@
 import { styled } from "@linaria/react";
 import type { ReactNode } from "react";
 
+import type { Layout } from "~/types";
+
 type Props = {
-  readonly pageMode: "page" | "popup";
+  readonly layout: Layout;
   readonly children: ReactNode;
 };
 
@@ -14,7 +16,7 @@ const StylePageContainer = styled.div`
   bottom: 16px;
 `;
 
-const StylePopupContainer = styled.div`
+const StyleCenterPeekContainer = styled.div`
   z-index: 1000;
   pointer-events: none;
   position: fixed;
@@ -26,17 +28,17 @@ const StylePopupContainer = styled.div`
   height: calc(100% - 144px);
 `;
 
-const StylePopupInner = styled.div`
+const StyleCenterPeekInner = styled.div`
   position: absolute;
   right: 16px;
   bottom: 16px;
 `;
 
-export const NotionContainer = ({ pageMode, children }: Props) =>
-  pageMode === "page" ? (
-    <StylePageContainer>{children}</StylePageContainer>
+export const NotionContainer = ({ layout, children }: Props) =>
+  layout === "center-peek" ? (
+    <StyleCenterPeekContainer>
+      <StyleCenterPeekInner>{children}</StyleCenterPeekInner>
+    </StyleCenterPeekContainer>
   ) : (
-    <StylePopupContainer>
-      <StylePopupInner>{children}</StylePopupInner>
-    </StylePopupContainer>
+    <StylePageContainer>{children}</StylePageContainer>
   );

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+export type Layout = "full-page" | "center-peek" | "side-peek";
+
 export type RuntimeMessageRequest =
   | {
       readonly message: "init";
@@ -20,14 +22,14 @@ export type TabMessageRequest =
       readonly message: "showLikeButton";
       readonly isLiked: boolean;
       readonly likeCount: number;
-      readonly pageMode: "page" | "popup";
+      readonly layout: Layout;
       readonly url: string;
     }
   | {
       readonly message: "updateLikeButton";
       readonly isLiked: boolean;
       readonly likeCount: number;
-      readonly pageMode: "page" | "popup";
+      readonly layout: Layout;
       readonly url: string;
     }
   | {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3059,6 +3059,11 @@
   resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-1.7.0.tgz#e1993689ac42d2b16e9194376cfb6753f6254db1"
   integrity sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==
 
+"@xobotyi/scrollbar-width@1.9.5":
+  version "1.9.5"
+  resolved "https://registry.yarnpkg.com/@xobotyi/scrollbar-width/-/scrollbar-width-1.9.5.tgz#80224a6919272f405b87913ca13b92929bdf3c4d"
+  integrity sha512-N8tkAACJx2ww8vFMneJmaAgmjAG1tnVBZJRLRcx061tmsLRZHSEZSLuGWnwPtunsSLvSqXQ2wfp7Mgqg1I+2dQ==
+
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@xtuc/ieee754/-/ieee754-1.2.0.tgz#eef014a3145ae477a1cbc00cd1e552336dceb790"


### PR DESCRIPTION
![2022-08-07 22 37 58](https://user-images.githubusercontent.com/1177538/183293561-fa8413c6-4191-4fe5-b4c0-1dc0bc027f88.gif)

- Added support for displaying child pages of side-peek, which is new to Notion.
- Also fixed a problem in which the display position of the Like Button would shift when the scrollbar was visible.
    - close #31