### PR TITLE
chore: update renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,12 +1,12 @@
 {
   "extends": [
-    "config:base",
+    "config:recommended",
     "group:definitelyTyped",
     "packages:linters",
-    ":maintainLockFilesWeekly"
+    ":maintainLockFilesWeekly",
+    "helpers:pinGitHubActionDigests"
   ],
   "postUpdateOptions": ["pnpmDedupe"],
-  "automerge": true,
   "packageRules": [
     {
       "groupName": "linaria",


### PR DESCRIPTION
<!-- title: chore: update renovate config -->
## 概要

Renovateの設定を見直しました。

- `config:base` を現在の名称である `config:recommended` に変更しました
- `helpers:pinGitHubActionDigests` を追加し、GitHub Actionsをコミットハッシュでピン留めするようにしました
- `automerge: true` を削除しました（依存関係の更新をレビューせずに自動マージしない運用に変更）

## 背景

`config:base` はRenovate側で `config:recommended` にリネームされており、現在も後方互換のため動作はしますが、公式ドキュメント上の呼称に合わせました。また、依存の自動更新に加えてGitHub Actions自体のサプライチェーンリスクを下げるため、Actionsをタグではなくコミットハッシュで固定するプリセットを追加しています。

## テスト計画

- [x] `renovate.json` がJSONとして妥当であることを確認
- [x] `pnpm lint` が通ることを確認
