### PR TITLE
chore: add fujikky as renovate reviewer

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,7 @@
     "helpers:pinGitHubActionDigests"
   ],
   "postUpdateOptions": ["pnpmDedupe"],
+  "reviewers": ["fujikky"],
   "packageRules": [
     {
       "groupName": "linaria",


### PR DESCRIPTION
<!-- title: chore: add fujikky as renovate reviewer -->
## 概要

`renovate.json` の `reviewers` に `fujikky` を追加します。

## 変更内容

- Renovate が作成する PR のレビュワーとして `fujikky` を指定するようにしました。
